### PR TITLE
Allow configurable seed in lattice for consistent results

### DIFF
--- a/lattice.go
+++ b/lattice.go
@@ -4,7 +4,12 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 )
+
+// This seed is used as the default seed when one does not care about
+// generating inconsistent shards across process boundaries.
+var seed = time.Now().UTC().UnixNano()
 
 // Lattice defines an N-dimensional lattice.
 type Lattice struct {
@@ -71,7 +76,9 @@ func indexOf(s []string, p string) int {
 }
 
 // NewLattice creates an N-dimensional Lattice for a given set of dimension
-// names, where each dimension represents a meaningful availability axis.
+// names, where each dimension represents a meaningful availability axis. It
+// uses a seed based on process start time. See NewLatticeWithSeed for seed
+// meaning and behavior.
 func NewLattice(dims []string) (*Lattice, error) {
 	return NewLatticeWithSeed(seed, dims)
 }

--- a/lattice.go
+++ b/lattice.go
@@ -28,6 +28,11 @@ type Lattice struct {
 	// have something like:
 	//      ["us-x", "v42"] -> [endpoints-in-us-x-running-v42].
 	EndpointsByCoordinate map[string][]string
+
+	// Seed is the seed to use for randomness. Shuffle sharding intends to use
+	// the seed as a sort of application ID to allow applications to
+	// consistently produce the same results.
+	Seed int64
 }
 
 // We need this because we can't have a slice for a key in a map,
@@ -68,12 +73,20 @@ func indexOf(s []string, p string) int {
 // NewLattice creates an N-dimensional Lattice for a given set of dimension
 // names, where each dimension represents a meaningful availability axis.
 func NewLattice(dims []string) (*Lattice, error) {
+	return NewLatticeWithSeed(seed, dims)
+}
+
+// NewLatticeWithSeed creates an N-dimensional Lattice for a given set of
+// dimension names, where each dimension represents a meaningful availability
+// axis. Seed is intended to be used as an application ID, so the same
+// application can create consistent results across restarts.
+func NewLatticeWithSeed(seed int64, dims []string) (*Lattice, error) {
 	if len(dims) == 0 {
 		return nil, fmt.Errorf("lattice: at least one dimension is required")
 	}
 
 	// Initialize an empty lattice.
-	l := &Lattice{[]string{}, map[string][]string{}, map[string][]string{}}
+	l := &Lattice{[]string{}, map[string][]string{}, map[string][]string{}, seed}
 
 	// Sort the dimensions.
 	sort.Strings(dims)

--- a/shard.go
+++ b/shard.go
@@ -39,11 +39,11 @@ func (l *Lattice) SimpleShuffleShard(id []byte, epc int) (*Lattice, error) {
 	)
 
 	// Create a seed a random generator.
-	shdSeed = int64(murmur3.Sum64WithSeed(id, uint32(seed)))
-	r = rand.New(rand.NewSource(seed * shdSeed * 42))
+	shdSeed = int64(murmur3.Sum64WithSeed(id, uint32(l.Seed)))
+	r = rand.New(rand.NewSource(l.Seed * shdSeed * 42))
 
 	// The "chosen" lattice, which will have the sharded endpoints.
-	shard, err = NewLattice(l.GetDimensionNames())
+	shard, err = NewLatticeWithSeed(l.Seed, l.GetDimensionNames())
 	if err != nil {
 		return nil, fmt.Errorf(
 			"shard: unable to create a sharded lattice: %v", err,

--- a/shard.go
+++ b/shard.go
@@ -10,13 +10,9 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"time"
 
 	"github.com/spaolacci/murmur3"
 )
-
-// We need a seed value for the random stuff.
-var seed = time.Now().UTC().UnixNano()
 
 // SimpleShuffleShard implementation uses simple probabilistic hashing to
 // compute shuffle shards. This function takes an existing lattice and


### PR DESCRIPTION
I would have liked to have opened an issue to discuss this before opening the PR, but it wasn't all that complicated, so I gave it a shot.

It's entirely possible that I'm misunderstanding shuffle sharding and or the math behind it, but this patch reflects how I understand shuffle sharding is intended to be implemented to allow consistent results across processes and restarts when desired.

Shuffle sharding specifically intends to use the seed used for
"randomness" to allow consistent results to be produced by the same
application.

This patch introduces a new NewLatticeWithSeed function that allows
setting the seed for the initial lattice, which will pass the seed down
to new lattices created by the SimpleShuffleShard function.

For backward compatibility the NewLattice function passes the package
level seed initialized at startup, thus users using NewLattice are
unaffected, but users can in the future choose to set the seed
themselves.

@clickyotomy 